### PR TITLE
Fix uv handle cleanup on exit

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -71,9 +71,17 @@ else
   end
 
   uv.walk(function (handle)
-    if handle and not handle:is_closing() then handle:close() end
+    if handle then
+      local function close()
+        if not handle:is_closing() then handle:close() end
+      end
+      if handle.shutdown then
+        handle:shutdown(close)
+      else
+        close()
+      end
+    end
   end)
   uv.run()
+  return exitCode
 end
-
-os.exit(exitCode)

--- a/package.lua
+++ b/package.lua
@@ -1,6 +1,6 @@
 return {
   name = "squeek502/luver",
-  version = "0.1.0",
+  version = "0.1.1",
   luvi = {
     version = "2.7.3",
     flavor = "regular",


### PR DESCRIPTION
See luvit/luvit#1007 and luvit/lit#222.

Also, your `os.exit(exitCode)` wasn't doing anything.